### PR TITLE
Refresh CAT062 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,89 @@
 # asterix-kotlin
 
-Kotlin/JVM codec for ASTERIX CAT062 System Track Data.
+`asterix-kotlin` is a Kotlin/JVM codec for ASTERIX CAT062 System Track Data.
 
-The project targets CAT062 v1.15 and provides:
+The repository is intentionally narrow:
 
-- Kotlin model types for CAT062 records and compound items
-- Typed enums and sealed `Known`/`Unknown(code)` models for spec-coded CAT062 fields
-- `ByteBuffer`-based read/write support for CAT062 records and complete data blocks
-- Round-trip tests for the current wire encoding
+- one ASTERIX category: CAT062
+- one target revision: CAT062 v1.15
+- one public entry point: `Cat062Codec`
+- one package namespace: `io.github.erikgust2.asterix.cat062`
+
+The CAT062 v1.15 PDF in the repository root,
+`cat062-asterix-system-track-data-part9-v1.15-20110901.pdf`, is the wire
+layout source of truth for item structure, scaling, extents, and UAP behavior.
+
+## What The Library Provides
+
+- `ByteBuffer`-oriented read and write APIs for CAT062 records and full
+  ASTERIX data blocks
+- convenience `ByteArray` overloads for the same operations
+- Kotlin model types for the implemented CAT062 items and compound structures
+- typed enums and sealed `Known` / `Unknown(code)` models for many CAT062 code
+  tables
+- write-side validation for mandatory CAT062 items and item-specific wire
+  constraints
+- a spec-driven regression suite with golden vectors, round-trips, and
+  malformed-input coverage
+
+## Documentation Map
+
+- [`docs/HOW_CAT062_WORKS.md`](docs/HOW_CAT062_WORKS.md): practical CAT062 and
+  ASTERIX explainer, including FSPEC, FRNs, UAP order, and a worked example
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md): how the codec is structured
+  internally and where to make changes
+- [`docs/TESTING_PLAN.md`](docs/TESTING_PLAN.md): implemented CAT062 coverage
+  map and verification expectations
 
 ## Requirements
 
 - Java 21
-- Maven 3.x
+- Maven 3.8.7 or newer
+- Kotlin 2.1.20 via the Maven build
 
-## Build And Test
+## Build And Verify
+
+Run the standard local checks:
 
 ```bash
 mvn test
+mvn verify
+mvn spotless:apply
 ```
 
-To build the jar as well:
+To produce the jar:
 
 ```bash
 mvn package
 ```
 
-To run the full local verification path used by CI:
+If you want a clean local Maven repository for repeatable runs, the test plan
+documents the `/tmp/m2` commands used in local verification.
 
-```bash
-mvn verify
-```
+## Public API
 
-To auto-format the Kotlin sources before committing:
+`Cat062Codec` exposes eight operations:
 
-```bash
-mvn spotless:apply
-```
+- `readDataBlock(buffer: ByteBuffer): Cat062DataBlock`
+- `readDataBlock(bytes: ByteArray): Cat062DataBlock`
+- `writeDataBlock(buffer: ByteBuffer, block: Cat062DataBlock)`
+- `writeDataBlock(block: Cat062DataBlock): ByteArray`
+- `readRecord(buffer: ByteBuffer): Cat062Record`
+- `readRecord(bytes: ByteArray): Cat062Record`
+- `writeRecord(buffer: ByteBuffer, record: Cat062Record)`
+- `writeRecord(record: Cat062Record): ByteArray`
 
-## API Overview
+The `ByteBuffer` methods are the core, lower-allocation path. The `ByteArray`
+overloads wrap or allocate buffers for convenience.
 
-The main entry point is `Cat062Codec`.
-
-- `Cat062Codec.readDataBlock(buffer)` reads a full ASTERIX CAT062 data block
-- `Cat062Codec.readDataBlock(bytes)` reads a full ASTERIX CAT062 data block from a `ByteArray`
-- `Cat062Codec.writeDataBlock(buffer, block)` writes a full ASTERIX CAT062 data block
-- `Cat062Codec.writeDataBlock(block)` writes a full ASTERIX CAT062 data block to a new `ByteArray`
-- `Cat062Codec.readRecord(buffer)` reads a single CAT062 record
-- `Cat062Codec.readRecord(bytes)` reads a single CAT062 record from a `ByteArray`
-- `Cat062Codec.writeRecord(buffer, record)` writes a single CAT062 record
-- `Cat062Codec.writeRecord(record)` writes a single CAT062 record to a new `ByteArray`
-
-The writer uses `ByteBuffer` directly, so the caller is responsible for
-allocating a large enough buffer and flipping it before reading.
-
-The `ByteArray` overloads are convenience helpers. They wrap decode input in a
-temporary `ByteBuffer`, and encode paths allocate an internal `ByteBuffer` plus
-the returned `ByteArray`. For hot paths or buffer reuse, prefer the explicit
-`ByteBuffer` methods.
-
-Decode and validation failures now include CAT062 item references such as
-`I062/080` where the codec can identify the failing item. Public data-block
-decode failures also include the one-based record ordinal when the failure is
-inside a nested record.
-
-## CAT062 Coverage Status
-
-Supported CAT062 item coverage is tracked in `docs/TESTING_PLAN.md`.
-
-Current explicit limitations:
-
-- `RE` and `SP` are preserved as raw length-prefixed payloads
-- spare FRNs `2`, `29`, `30`, `31`, `32`, and `33` are unsupported and rejected on decode
+Decode and validation failures include CAT062 item references such as
+`I062/080` where the codec can identify the failing item. Nested failures while
+reading a full data block also include the one-based record ordinal.
 
 ## Minimal Example
 
-```kotlin
-import io.github.erikgust2.asterix.cat062.Cat062DataBlock
-import io.github.erikgust2.asterix.cat062.Cat062Codec
-import io.github.erikgust2.asterix.cat062.Cat062Record
-import io.github.erikgust2.asterix.cat062.DataSourceIdentifier
-import io.github.erikgust2.asterix.cat062.TrackSource
-import io.github.erikgust2.asterix.cat062.TrackStatus
-import java.nio.ByteBuffer
-
-val buffer = ByteBuffer.allocate(1024)
-val record = Cat062Record(
-    dataSourceIdentifier = DataSourceIdentifier(1, 2),
-    serviceIdentification = 4,
-    trackNumber = 42,
-    timeOfTrackInformationSeconds = 12_345.0,
-    trackStatus = TrackStatus(
-        mon = true,
-        spi = false,
-        mrh = false,
-        src = TrackSource.THREE_D_RADAR,
-        cnf = true,
-    ),
-)
-
-Cat062Codec.writeDataBlock(
-    buffer,
-    Cat062DataBlock(listOf(record)),
-)
-
-buffer.flip()
-val decoded = Cat062Codec.readDataBlock(buffer)
-```
-
-## Convenience Example
+`writeRecord` enforces the CAT062 mandatory items from the v1.15 UAP:
+`I062/010`, `I062/040`, `I062/070`, and `I062/080`.
 
 ```kotlin
 import io.github.erikgust2.asterix.cat062.Cat062Codec
@@ -119,8 +94,8 @@ import io.github.erikgust2.asterix.cat062.TrackStatus
 
 val record = Cat062Record(
     dataSourceIdentifier = DataSourceIdentifier(1, 2),
-    trackNumber = 42,
     timeOfTrackInformationSeconds = 12_345.0,
+    trackNumber = 42,
     trackStatus = TrackStatus(
         mon = true,
         spi = false,
@@ -134,34 +109,63 @@ val bytes = Cat062Codec.writeRecord(record)
 val decoded = Cat062Codec.readRecord(bytes)
 ```
 
-`writeRecord` enforces the CAT062 mandatory items from the v1.15 UAP:
-`I062/010`, `I062/040`, `I062/070`, and `I062/080`.
+For higher-throughput paths, manage the destination buffer directly:
 
-For `I062/270` Target Size & Orientation, the model follows the wire extents:
-`orientationDegrees = null` means length-only, `orientationDegrees != null`
-with `widthMeters = null` means orientation is present without width, and
-`widthMeters` requires `orientationDegrees`.
+```kotlin
+import io.github.erikgust2.asterix.cat062.Cat062Codec
+import io.github.erikgust2.asterix.cat062.Cat062DataBlock
+import java.nio.ByteBuffer
 
-For semantic CAT062 code tables such as track source, report type, flight
-category, selected-altitude source, and ADS-B / Mode-S status fields, the
-public model now uses typed enums or sealed `Known` / `Unknown(code)` values
-instead of raw integers.
+val buffer = ByteBuffer.allocate(1024)
+Cat062Codec.writeDataBlock(buffer, Cat062DataBlock(listOf(record)))
+buffer.flip()
 
-Sparse code tables that may grow in future revisions, such as trajectory
-intent point type in `I062/380`, use sealed `Known` / `Unknown(code)` models
-so unknown decode values can still round-trip losslessly.
+val decodedBlock = Cat062Codec.readDataBlock(buffer)
+```
 
-## Scope
+## CAT062 Model Notes
 
-This repository currently only supports CAT062 System Track Data, and is not yet a general ASTERIX
-framework for multiple categories.
+`Cat062Record` is a sparse aggregate model. Most fields are nullable, and
+`null` generally means the corresponding CAT062 item is absent from the record.
+
+Important semantics to know:
+
+- `TrackStatus` models CAT062 `I062/080` extents explicitly. Octet 1 is always
+  required when the item is present, and later extents must be complete rather
+  than partially null.
+- `TargetSizeAndOrientation` models `I062/270` extent presence directly:
+  `orientationDegrees == null` means length only, and `widthMeters` requires
+  `orientationDegrees`.
+- `RE` and `SP` are preserved as raw length-prefixed payloads through
+  `RawBytes`. They round-trip byte-for-byte, but the library does not yet
+  expose richer spec-level models for their contents.
+- Several code tables use sealed `Known` / `Unknown(code)` models so unknown
+  wire values can still be decoded and re-encoded losslessly.
+
+## Current Support Boundary
+
+The codec currently implements the non-spare UAP items represented in
+`Cat062Record` and its related type files. The test coverage map in
+[`docs/TESTING_PLAN.md`](docs/TESTING_PLAN.md) is the authoritative list of
+implemented FRNs and their current regression coverage.
+
+Current explicit limitations:
+
+- spare FRNs `2`, `29`, `30`, `31`, `32`, and `33` are unsupported and rejected
+  on decode
+- `RE` and `SP` are intentionally opaque pass-through payloads
+- this repository is CAT062-only, not a general multi-category ASTERIX
+  framework
 
 ## Project Layout
 
 - `src/main/kotlin/io/github/erikgust2/asterix/cat062`: codec and model types
-- `src/test/kotlin/io/github/erikgust2/asterix/cat062`: codec tests
-- `docs/ARCHITECTURE.md`: how the current codec is structured internally
-- `cat062-asterix-system-track-data-part9-v1.15-20110901.pdf`: local reference spec
+- `src/test/kotlin/io/github/erikgust2/asterix/cat062`: spec-driven tests
+- `docs/ARCHITECTURE.md`: internal structure and extension guidance
+- `docs/TESTING_PLAN.md`: active coverage map
+- `docs/HOW_CAT062_WORKS.md`: CAT062 explainer and worked wire example
+- `cat062-asterix-system-track-data-part9-v1.15-20110901.pdf`: local reference
+  specification
 
 ## Coordinates
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,13 +1,16 @@
 # Architecture
 
-This document describes how the current `asterix-kotlin` codebase is organized,
-how data flows through it, and where to make changes when extending the codec.
+This document explains how the current `asterix-kotlin` codebase is organized,
+how CAT062 data flows through it, and where to make changes without losing the
+spec-driven structure of the codec.
+
+For a practical walkthrough of ASTERIX blocks, FSPEC, FRNs, and CAT062 item
+semantics, read [`HOW_CAT062_WORKS.md`](HOW_CAT062_WORKS.md) first.
 
 ## Scope
 
 The repository is a Kotlin/JVM codec for ASTERIX CAT062 System Track Data,
-currently aligned to the local CAT062 v1.15 reference PDF in the repository
-root.
+aligned to the CAT062 v1.15 PDF in the repository root.
 
 It is intentionally narrow in scope:
 
@@ -16,56 +19,75 @@ It is intentionally narrow in scope:
 - one public entry point: `Cat062Codec`
 - one model namespace: `io.github.erikgust2.asterix.cat062`
 
-It is not yet a general multi-category ASTERIX framework.
+It is not a general multi-category ASTERIX framework.
 
-## High-Level Structure
+## High-Level Layout
 
 The important code lives under:
 
 - `src/main/kotlin/io/github/erikgust2/asterix/cat062`
 - `src/test/kotlin/io/github/erikgust2/asterix/cat062`
 
-The main files and responsibilities are:
+Key production files:
 
 - `Cat062Codec.kt`
-  - public API
-  - reads and writes whole CAT062 data blocks and single records
+  - public API for record and data-block read/write
+  - `ByteBuffer` core path plus convenience `ByteArray` overloads
+  - ASTERIX category and block-length framing for full data blocks
 - `Cat062CodecSupport.kt`
-  - record-level orchestration
-  - FSPEC parsing and writing
+  - CAT062 record orchestration
+  - FSPEC decoding and encoding
   - FRN-to-field dispatch
-  - mandatory field enforcement on write
+  - write-side mandatory-item enforcement
+  - public error-context enrichment with CAT062 item references
 - `Cat062CodecWire.kt`
-  - low-level wire primitives
-  - fixed-length field codecs
-  - integer packing helpers
+  - low-level fixed-width wire helpers
+  - signed and unsigned packing helpers
+  - quantization and range enforcement
   - length-prefixed field handling
+  - compound-indicator helpers reused by complex items
 - `Cat062CodecTrackState.kt`
-  - codecs for track status, mode of movement, system track update ages, and
-    track data ages
+  - `I062/080`, `I062/200`, `I062/290`, and `I062/295`
 - `Cat062CodecAircraftDerivedData.kt`
-  - compound codec for `I062/380` aircraft derived data
+  - `I062/380`
 - `Cat062CodecFlightPlan.kt`
-  - compound codec for `I062/390` flight plan related data
+  - `I062/390`
 - `Cat062CodecMode5.kt`
-  - codec for `I062/110` mode 5 data reports and related fields
+  - `I062/110`
 - `Cat062CodecEstimatedAccuracies.kt`
-  - codec for `I062/500` estimated accuracies
+  - `I062/500`
 - `Cat062CodecMeasuredInformation.kt`
-  - codec for `I062/340` measured information
+  - `I062/340`
 - `Cat062Record.kt`
-  - top-level `Cat062Record` and `Cat062DataBlock` models
+  - `Cat062Record` and `Cat062DataBlock`
 - `Cat062*Types.kt`
-  - model types grouped by domain
-  - common, track, aircraft-derived, measured, flight plan, mode 5, etc.
+  - typed model layer grouped by domain
 - `Cat062ByteArraySupport.kt`
-  - `ByteArray` helpers such as `RawBytes` for value semantics
+  - `RawBytes` and byte-array helpers with value semantics
+
+## Wire Model
+
+At the ASTERIX layer, a CAT062 data block is:
+
+1. category byte `62`
+2. two-byte block length
+3. one or more CAT062 records
+
+Each CAT062 record is:
+
+1. an FSPEC of one or more octets
+2. item payloads for the FRNs selected by that FSPEC
+3. payloads written in UAP order, not arbitrary field order
+
+The codec keeps these layers separate:
+
+- `Cat062Codec.kt` owns ASTERIX block framing
+- `Cat062CodecSupport.kt` owns CAT062 record orchestration
+- item-specific functions own the payload details
 
 ## Public API
 
-The public entry point is `Cat062Codec`.
-
-It exposes eight operations:
+`Cat062Codec` exposes:
 
 - `readDataBlock(buffer: ByteBuffer): Cat062DataBlock`
 - `readDataBlock(bytes: ByteArray): Cat062DataBlock`
@@ -76,48 +98,52 @@ It exposes eight operations:
 - `writeRecord(buffer: ByteBuffer, record: Cat062Record)`
 - `writeRecord(record: Cat062Record): ByteArray`
 
-The API is still `ByteBuffer`-oriented at its core. The `ByteArray` overloads
-are convenience wrappers around that core path. Read-side wrappers allocate a
-temporary `ByteBuffer` object but do not copy the input bytes; write-side
-wrappers allocate an internal `ByteBuffer` and the returned `ByteArray`, and
-may retry with a larger buffer for bigger payloads. Performance-sensitive code
-should continue using the explicit `ByteBuffer` methods. The library does not
-currently expose stream adapters or higher-level builders. It does provide
-`RawBytes` for length-prefixed binary payloads that need value semantics.
+Design choices worth preserving:
 
-## Data Flow
+- `ByteBuffer` is the primary abstraction, not streams or builders
+- `ByteArray` overloads are convenience wrappers, not a second code path
+- full data-block APIs add ASTERIX framing while single-record APIs operate on
+  raw CAT062 records
 
-### Reading
+## Read Path
 
-Reading a full CAT062 block works like this:
+Reading a full data block works like this:
 
-1. `Cat062Codec.readDataBlock` verifies the category byte is `62`.
-2. It reads the ASTERIX block length.
-3. It repeatedly calls `readRecord` until the block boundary is reached.
-4. `Cat062CodecSupport.readRecord` reads the FSPEC.
-5. The FSPEC is converted into a list of FRNs.
-6. Each FRN dispatches to the item-specific reader for that field.
-7. The record is assembled incrementally with `copy(...)` calls on
-   `Cat062Record`.
+1. `Cat062Codec.readDataBlock` verifies category `62`.
+2. It reads the ASTERIX block length and computes the block boundary.
+3. It repeatedly calls `readRecord` until the boundary is reached.
+4. Nested record failures are wrapped with the one-based record ordinal.
 
-This means the record decoder is table-driven by FRN order, not by hand-written
-per-record parsing logic.
+Reading a single record works like this:
 
-### Writing
+1. `Cat062CodecSupport.readRecord` reads the FSPEC.
+2. The FSPEC is expanded into present FRNs.
+3. FRNs dispatch through a table-driven `when` block.
+4. Each FRN reader updates a `Cat062Record` via `copy(...)`.
+5. Item-level failures are wrapped so public errors include the relevant
+   CAT062 item reference where known.
 
-Writing runs in the opposite direction:
+This is intentionally UAP-driven. The decoder is controlled by FRN presence and
+order, not by ad hoc per-record parsing logic.
 
-1. `Cat062Codec.writeDataBlock` writes the category byte and reserves space for
-   the block length.
-2. Each record is written by `Cat062CodecSupport.writeRecord`.
-3. `writeRecord` first validates CAT062 mandatory items.
-4. It computes the list of present FRNs from the non-null fields of
-   `Cat062Record`.
-5. It writes the FSPEC for those FRNs.
-6. It writes item payloads in FRN order.
-7. `writeDataBlock` backfills the final ASTERIX block length.
+## Write Path
 
-The current mandatory items enforced on write are:
+Writing a single record works like this:
+
+1. `Cat062CodecSupport.writeRecord` checks mandatory items.
+2. It computes the present FRN list from non-null `Cat062Record` fields.
+3. It writes the FSPEC for those FRNs.
+4. It writes item payloads in FRN order.
+5. Item-specific writers enforce range and extent rules with `require(...)`.
+
+Writing a full data block adds ASTERIX framing:
+
+1. `Cat062Codec.writeDataBlock` writes category `62`.
+2. It reserves two bytes for the block length.
+3. It writes each record through the normal record writer.
+4. It backfills the final length.
+
+Mandatory items currently enforced on write:
 
 - `I062/010` Data Source Identifier
 - `I062/040` Track Number
@@ -126,115 +152,74 @@ The current mandatory items enforced on write are:
 
 ## Model Layer
 
-`Cat062Record` is the aggregate model for a single CAT062 record. Nearly all
-fields are nullable. Null usually means "item absent from the record".
+`Cat062Record` is the aggregate model for one CAT062 record. Most fields are
+nullable and `null` normally means that item is absent from the FSPEC.
 
-`I062/080` Track Status is the main exception to treat carefully: null is only
-used for absent extents, not for absent individual bits inside a present
-extent. Octet 1 is always required, and if any later extent is present then all
-fields in that extent, and every earlier implied extent, must be specified.
-Write-side validation rejects partially specified extents so the model does not
-silently collapse null into spec-default zero bits.
+The model is split by domain:
 
-`I062/270` Target Size & Orientation also has dependent extent semantics on
-write. `orientationDegrees == null` means only the first octet with length is
-present, `orientationDegrees != null && widthMeters == null` means the first
-extent is present without the second, and `widthMeters != null` requires
-`orientationDegrees != null` because width only exists in the second extent.
+- `Cat062CommonTypes.kt`: shared scalar and fixed-width structures
+- `Cat062TrackTypes.kt`: track state, track ages, movement, accuracies, fleet
+  identification
+- `Cat062AircraftTypes.kt`: aircraft-derived data and related code tables
+- `Cat062FlightPlanTypes.kt`: flight-plan related structures
+- `Cat062Mode5Types.kt`: mode 5 data
+- `Cat062MeasuredTypes.kt`: measured-information structures
 
-The supporting type files group related models by domain:
+Important modeling conventions:
 
-- `Cat062CommonTypes.kt`
-- `Cat062TrackTypes.kt`
-- `Cat062AircraftTypes.kt`
-- `Cat062MeasuredTypes.kt`
-- `Cat062FlightPlanTypes.kt`
-- `Cat062Mode5Types.kt`
+- fixed and simple items use plain Kotlin data classes and enums where the
+  code table is closed and stable
+- sparse or potentially extensible code tables use sealed `Known` /
+  `Unknown(code)` models so unknown values can still round-trip unchanged
+- opaque binary payloads use `RawBytes` to get value semantics instead of raw
+  `ByteArray` reference equality
 
-The code uses plain Kotlin data classes heavily. Spec-coded fields that have a
-stable CAT062 meaning are now modeled as enums or sealed `Known` /
-`Unknown(code)` families at the model layer, and the codecs map those values
-through `fromCode(...)` and `.code` helpers rather than duplicating tables
-inline. Truly numeric identifiers, counters, and opaque binary payloads remain
-numeric.
+## Extent And Presence Semantics
 
-Closed code tables that fully cover the extracted wire bit range can stay as
-enums. Sparse tables that may receive new spec-defined values should use sealed
-`Known` / `Unknown(code)` families so decode stays forward-compatible and
-unknown values can be re-encoded unchanged.
+Some CAT062 items need more than plain nullability.
 
-`RawBytes` is a small wrapper around `ByteArray` used where binary payloads need
-value semantics instead of reference equality.
+`I062/080` Track Status:
 
-Some CAT062 substructures are intentionally still opaque pass-through payloads
-rather than fully decoded models. The remaining examples are the `RE` and `SP`
-length-prefixed payloads.
+- octet 1 is always required when the item is present
+- later extents are optional
+- if a later extent is present, all fields in that extent must be specified
+- the writer rejects partially specified extents rather than silently encoding
+  zero/default bits
 
-## Fixed vs Compound Items
+`I062/270` Target Size & Orientation:
 
-There are two broad codec styles in the repository.
+- `orientationDegrees == null` means only the first octet with length is
+  present
+- `orientationDegrees != null && widthMeters == null` means the first extent is
+  present but the second is absent
+- `widthMeters != null` requires `orientationDegrees != null`
 
-### Fixed-Length and Primitive Items
+Compound items such as `I062/380`, `I062/390`, `I062/500`, and `I062/340` use
+their own presence indicators and subfield-specific rules inside the dedicated
+codec files.
 
-These mostly live in `Cat062CodecWire.kt` and handle:
+## Error Model
 
-- scalar numeric conversions
-- fixed-width integer packing
-- signed and unsigned interpretation
-- simple multi-octet structures
+The public API uses runtime exceptions for invalid input and invalid write-side
+state.
 
-Examples:
+Current behavior:
 
-- positions
-- velocities
-- mode 2 / mode 3 codes
-- barometric altitude
-- length-prefixed reserved fields
+- truncation normally surfaces as `IllegalArgumentException`
+- record and item context is added close to the failure site
+- item references such as `I062/390` are preserved in public messages where the
+  codec can identify the failing item
+- full data-block decode failures add the one-based record ordinal
 
-### Compound and Variable-Length Items
+This context enrichment is part of the public usability of the codec and should
+be preserved during refactors.
 
-These live in the focused domain codec files and handle:
+## Testing Structure
 
-- compound presence indicators
-- variable extents
-- repeated subfields
-- items whose shape depends on flags
-
-Examples:
-
-- aircraft derived data
-- track status
-- system track update ages
-- track data ages
-- flight plan related data
-- estimated accuracies
-- measured information
-
-If you need to work on a complex spec item, start in the codec file named for
-that domain.
-
-## Internal Conventions
-
-The codebase follows a few important conventions:
-
-- FRNs are encoded and decoded through FSPEC helper logic in
-  `Cat062CodecSupport.kt`.
-- Compound subfield presence is encoded and decoded through helper functions in
-  `Cat062CodecWire.kt`, then composed by the focused domain codec files.
-- Field-specific validation is usually enforced at write time with `require(...)`.
-- Decode and validation failures are enriched close to record/item dispatch so
-  public errors carry CAT062 item references such as `I062/080`; compound
-  codec entry points add subfield context where that materially improves
-  truncation diagnostics.
-- Reads are mostly permissive about default values and absent optional fields.
-- Writes are generally driven by nullability: non-null fields become present
-  items or subfields.
-
-## Testing Strategy
-
-The test suite is split by codec area:
+The regression suite is organized by codec area:
 
 - `Cat062CodecDataBlockTest`
+- `Cat062CodecGoldenVectorTest`
 - `Cat062CodecSupportTest`
 - `Cat062CodecWireFixedItemsTest`
 - `Cat062CodecTrackStateTest`
@@ -245,62 +230,54 @@ The test suite is split by codec area:
 - `Cat062CodecMeasuredInformationTest`
 - `Cat062TestSupport`
 
-The test suite covers:
-
-- public record and data-block round trips through both `ByteBuffer` and `ByteArray` entry points
-- FSPEC bit layout and FRN dispatch behavior
-- spec-layout assertions for fixed and compound items
-- malformed-input and truncation behavior
-- mandatory item enforcement on write
-
-The local CAT062 v1.15 PDF is the source of truth for spec alignment.
 `docs/TESTING_PLAN.md` is the active coverage map and should stay aligned with
-the current suite layout.
-
-## Current Architectural Strengths
-
-- Small public API
-- Clear separation between public API, record orchestration, wire helpers, and
-  model types
-- Focused domain codec files for the more complex CAT062 items
-- Strong use of value types
-- Spec-driven write validation in several places
-- Fast local test cycle
-
-## Current Architectural Constraints
-
-- The API is low-level and buffer-oriented
-- Some spec fields still remain intentionally numeric when the CAT062 PDF only
-  exposes opaque category numbers rather than stable named semantics
-- Several CAT062 compound items remain inherently complex even after file
-  splitting
-- The project is category-specific, so cross-category ASTERIX reuse is limited
+the implemented item set and suite layout.
 
 ## How To Extend The Codec
 
 When adding or fixing a CAT062 item:
 
-1. Confirm the wire layout in the v1.15 PDF.
-2. Update or add model fields in the relevant `Cat062*Types.kt` file.
+1. Confirm the wire layout in the CAT062 v1.15 PDF.
+2. Decide whether the model belongs in an existing `Cat062*Types.kt` file or a
+   new one.
 3. Add read and write logic in the correct codec file:
    - fixed/simple item: usually `Cat062CodecWire.kt`
-   - track state and ages: `Cat062CodecTrackState.kt`
+   - track-state and age items: `Cat062CodecTrackState.kt`
    - aircraft-derived data: `Cat062CodecAircraftDerivedData.kt`
-   - flight plan data: `Cat062CodecFlightPlan.kt`
+   - flight-plan data: `Cat062CodecFlightPlan.kt`
    - mode 5 data: `Cat062CodecMode5.kt`
    - estimated accuracies: `Cat062CodecEstimatedAccuracies.kt`
    - measured information: `Cat062CodecMeasuredInformation.kt`
-4. Wire the item into FRN dispatch in `Cat062CodecSupport.kt`.
-5. Add or update the focused test file for that codec area.
-6. Update `README.md`, `docs/TESTING_PLAN.md`, and this document if the public
-   API, coverage map, or architecture description changed.
+4. Wire the item into the FRN dispatch and present-FRN calculation in
+   `Cat062CodecSupport.kt`.
+5. Add or update focused tests for round-trip, spec-layout, and malformed-input
+   behavior.
+6. Update `README.md`, `docs/HOW_CAT062_WORKS.md`, `docs/TESTING_PLAN.md`, and
+   this document if the support boundary or architecture changed.
 
-## What Future Refactors Should Preserve
+## Architectural Strengths
 
-If you refactor this codebase later, preserve these properties:
+- small and obvious public API
+- clear separation between ASTERIX framing, record orchestration, wire helpers,
+  and domain-specific compound codecs
+- model types that keep spec semantics visible in Kotlin
+- strong write-side validation for mandatory items and wire ranges
+- regression tests that pin exact bytes for representative records and data
+  blocks
 
-- `Cat062Codec` remains the obvious public entry point
-- FSPEC handling stays centralized
-- item-specific wire logic stays isolated from model definitions
-- tests remain spec-oriented, not just happy-path object equality checks
-- mandatory CAT062 write constraints remain enforced
+## Architectural Constraints
+
+- the public API is intentionally low-level and `ByteBuffer`-oriented
+- some CAT062 structures remain inherently dense and spec-heavy
+- `RE` and `SP` are still opaque payloads rather than decoded sub-models
+- the repository is category-specific, so cross-category ASTERIX reuse is
+  intentionally limited
+
+## Refactors Should Preserve
+
+- `Cat062Codec` as the obvious public entry point
+- centralized FSPEC handling
+- centralized FRN ordering and dispatch
+- separation between model definitions and wire logic
+- spec-driven tests, not only object-equality round-trips
+- mandatory CAT062 write constraints

--- a/docs/HOW_CAT062_WORKS.md
+++ b/docs/HOW_CAT062_WORKS.md
@@ -1,0 +1,273 @@
+# How CAT062 Works
+
+This document is a practical introduction to ASTERIX CAT062 as implemented by
+`asterix-kotlin`.
+
+It is not a substitute for the CAT062 v1.15 PDF in the repository root. The
+PDF remains the wire-layout source of truth. The goal here is to explain the
+shape of the format, the terms used in the codebase, and how the library maps
+CAT062 records into Kotlin types.
+
+## Start With ASTERIX
+
+ASTERIX messages are organized as category-specific data blocks. For CAT062,
+the block layout is:
+
+1. category byte `62`
+2. two-byte block length
+3. one or more CAT062 records
+
+`Cat062Codec.readDataBlock(...)` and `writeDataBlock(...)` handle that outer
+framing.
+
+Inside the block, CAT062 is record-oriented. Each record represents one system
+track and contains only the items declared present by its FSPEC.
+
+## What FSPEC Means
+
+FSPEC stands for Field Specification.
+
+It is a compact bitmask at the start of every CAT062 record. Each bit selects a
+Field Reference Number, or FRN. The FRN identifies one UAP entry such as:
+
+- `I062/010` Data Source Identifier
+- `I062/040` Track Number
+- `I062/070` Time Of Track Information
+- `I062/080` Track Status
+
+Important FSPEC rules:
+
+- bits 8 down to 2 in each FSPEC octet represent seven FRNs
+- bit 1 is the FX bit
+- FX set to `1` means another FSPEC octet follows
+- FX set to `0` means the FSPEC ends there
+
+The codec expands the FSPEC into a list of FRNs, then decodes item payloads in
+UAP order.
+
+## What The UAP Does
+
+CAT062 defines a User Application Profile, or UAP. The UAP assigns each FRN to
+one CAT062 item and fixes the order in which present item payloads appear in
+the record.
+
+That order matters.
+
+CAT062 records do not carry per-item length tags for every item. After the
+FSPEC, the decoder must already know which items are present and in which order
+to parse the following bytes correctly.
+
+In this repository, that mapping lives in `Cat062CodecSupport.kt`:
+
+- `readRecord(...)` reads the FSPEC and dispatches FRNs to item readers
+- `writeRecord(...)` computes present FRNs from the non-null model fields and
+  writes payloads in UAP order
+
+## The Minimal Record In This Library
+
+The writer enforces the CAT062 mandatory items used by this project:
+
+- `I062/010` Data Source Identifier
+- `I062/040` Track Number
+- `I062/070` Time Of Track Information
+- `I062/080` Track Status
+
+That means the smallest writable `Cat062Record` in this library still needs
+those four items.
+
+Example:
+
+```kotlin
+val record = Cat062Record(
+    dataSourceIdentifier = DataSourceIdentifier(1, 2),
+    timeOfTrackInformationSeconds = 128.0,
+    trackNumber = 42,
+    trackStatus = TrackStatus(
+        mon = true,
+        spi = false,
+        mrh = false,
+        src = TrackSource.TRIANGULATION,
+        cnf = true,
+    ),
+)
+```
+
+The golden-vector test pins the encoded bytes for that record:
+
+```text
+91 0C 01 02 00 40 00 00 2A 8E
+```
+
+Breakdown:
+
+```text
+91 0C    FSPEC
+01 02    I062/010 Data Source Identifier
+00 40 00 I062/070 Time Of Track Information
+00 2A    I062/040 Track Number
+8E       I062/080 Track Status
+```
+
+FSPEC details:
+
+- `0x91` = `1001 0001`
+  - FRN 1 present
+  - FRN 4 present
+  - FX set, so a second FSPEC octet follows
+- `0x0C` = `0000 1100`
+  - FRN 12 present
+  - FRN 13 present
+  - FX clear, so FSPEC ends
+
+So the decoder knows that the record contains FRNs `1`, `4`, `12`, and `13`,
+in that order.
+
+## How Items Differ
+
+CAT062 items are not all shaped the same way. In practice, you will see four
+main patterns.
+
+### 1. Fixed-width items
+
+These are simple items with a fixed number of bytes and direct scaling rules.
+
+Examples:
+
+- `I062/010` Data Source Identifier
+- `I062/040` Track Number
+- `I062/070` Time Of Track Information
+- `I062/105` WGS-84 position
+- `I062/100` Cartesian position
+
+These mostly live in `Cat062CodecWire.kt`.
+
+### 2. Items with bit fields
+
+These still have fixed width, but their contents are split into flags and small
+code tables.
+
+Examples:
+
+- `I062/060` Track Mode 3/A Code
+- `I062/120` Track Mode 2 Code
+- `I062/135` Barometric altitude
+- `I062/200` Mode Of Movement
+
+The library usually maps stable code tables to enums instead of leaving them as
+raw integers.
+
+### 3. Compound items
+
+These items contain their own presence indicator and then a variable set of
+subfields.
+
+Examples:
+
+- `I062/380` Aircraft Derived Data
+- `I062/390` Flight Plan Related Data
+- `I062/500` Estimated Accuracies
+- `I062/340` Measured Information
+
+These use dedicated codec files because the logic is too dense to keep inside
+the generic record dispatcher.
+
+### 4. Extent-based items
+
+These items grow octet by octet, where a low bit indicates that another extent
+follows.
+
+Examples:
+
+- `I062/080` Track Status
+- `I062/270` Target Size & Orientation
+
+These are easy to mis-model if you treat every nullable field as an optional
+bit. The library models their extent rules explicitly.
+
+## How The Kotlin Model Maps To CAT062
+
+`Cat062Record` is the aggregate model for one record.
+
+Most properties are nullable:
+
+- non-null means the item is present and must be written
+- null usually means the item is absent from the FSPEC
+
+This makes the mapping from model presence to FRN presence straightforward.
+
+Important exceptions and special cases:
+
+- `TrackStatus` must respect CAT062 extent rules. Later extents cannot be
+  partially specified.
+- `TargetSizeAndOrientation` encodes extent presence directly:
+  - `orientationDegrees == null` means length only
+  - `orientationDegrees != null && widthMeters == null` means orientation
+    present, width absent
+  - `widthMeters != null` requires `orientationDegrees != null`
+- `RE` and `SP` are modeled as `RawBytes`
+  - the library preserves their bytes and their length-prefix framing
+  - it does not yet decode their internal structure into richer models
+
+## Why Some Fields Use `Known` / `Unknown(code)`
+
+Some CAT062 code tables are stable and closed enough for enums.
+
+Other tables are sparse or may gain future values. For those, the library uses
+sealed `Known` / `Unknown(code)` models. That gives two useful properties:
+
+- known values decode to readable named variants
+- unknown values can still round-trip without being discarded or normalized
+
+This is important for forward-compatible byte preservation.
+
+## How Reading Works In The Codec
+
+`Cat062Codec.readRecord(...)` does not try to parse a record by guessing.
+
+The sequence is:
+
+1. read the FSPEC
+2. expand it to FRNs
+3. dispatch each FRN to the correct item reader
+4. update the `Cat062Record`
+
+`readDataBlock(...)` adds the ASTERIX framing around that:
+
+1. verify category `62`
+2. read the block length
+3. decode records until the block boundary
+4. include the record ordinal if a nested decode fails
+
+## How Writing Works In The Codec
+
+Writing goes in the opposite direction:
+
+1. validate mandatory items
+2. collect the FRNs implied by non-null model fields
+3. write the FSPEC
+4. write payloads in UAP order
+
+This means the Kotlin model is not just a convenient data holder. It directly
+controls the encoded CAT062 record shape.
+
+## Opaque Areas And Current Limits
+
+The codec is intentionally not a full decoder for every conceptual area of
+CAT062.
+
+Current important limits:
+
+- spare FRNs `2`, `29`, `30`, `31`, `32`, and `33` are unsupported and rejected
+- `RE` and `SP` are preserved but not semantically decoded
+- the repository is CAT062-only
+
+Those limits are deliberate. They keep the project narrow and keep the
+implemented part of the format well tested.
+
+## Where To Go Next
+
+- Read [`ARCHITECTURE.md`](ARCHITECTURE.md) if you want to change the codec.
+- Read [`TESTING_PLAN.md`](TESTING_PLAN.md) if you want to understand which FRNs
+  are already covered and how regressions are pinned.
+- Read the CAT062 v1.15 PDF in the repository root before changing any wire
+  behavior.

--- a/docs/TESTING_PLAN.md
+++ b/docs/TESTING_PLAN.md
@@ -1,33 +1,60 @@
 # Testing Plan
 
-This document is the active CAT062 test coverage map for `asterix-kotlin`.
+This document is the active CAT062 regression coverage map for
+`asterix-kotlin`.
 
-It is aligned to the CAT062 v1.15 PDF in the repository root and tracks the
-implemented User Application Profile (UAP) items, the current test suite
-layout, and the remaining follow-up gaps.
+It is aligned to the CAT062 v1.15 PDF in the repository root and tracks:
+
+- the implemented CAT062 UAP items
+- the current test-suite layout
+- the kinds of byte-level and malformed-input behavior that are pinned by tests
+- the explicit support boundary of the current codec
+
+For a conceptual CAT062 walkthrough, read
+[`HOW_CAT062_WORKS.md`](HOW_CAT062_WORKS.md). For code structure, read
+[`ARCHITECTURE.md`](ARCHITECTURE.md).
 
 ## Scope
 
 Source of truth:
 
 - `cat062-asterix-system-track-data-part9-v1.15-20110901.pdf`
-- UAP pages 129-131
+- CAT062 v1.15 UAP pages 129-131
 
 In scope:
 
 - every implemented non-spare UAP item in the codec
 - public `Cat062Codec` record and data-block behavior
 - FSPEC generation and parsing
-- malformed-input and truncation behavior
+- fixed-width item layout and quantization behavior
+- compound-item presence indicators, extents, and repetition semantics
+- malformed-input, truncation, and range-failure behavior
+- forward-compatible decoding for modeled `Known` / `Unknown(code)` families
 
 Out of scope:
 
-- spare FRNs `2`, `29`, `30`, `31`, `32`, `33`
-- adding new production codec features or new ASTERIX categories
-- a JaCoCo build gate
+- spare FRNs `2`, `29`, `30`, `31`, `32`, and `33`
+- adding new production codec features
+- adding support for ASTERIX categories other than CAT062
+- introducing a JaCoCo build gate
 
-The spare FRNs are still covered as decode failures so unsupported-item
+The spare FRNs are still covered as explicit decode failures so unsupported-FRN
 handling is exercised.
+
+## Regression Strategy
+
+The suite is intentionally spec-driven, not just object-driven.
+
+Core assertions used throughout the suite:
+
+- exact byte-for-byte golden vectors for representative records and full data
+  blocks
+- public round-trips through both `ByteBuffer` and `ByteArray` entry points
+- direct field-level wire assertions for fixed-width items
+- compound-item presence, extent, and repetition coverage
+- targeted malformed-input tests for truncation, invalid lengths, and
+  out-of-range writes
+- typed-code coverage proving known decode and lossless unknown re-encode
 
 ## Current Suite Layout
 
@@ -50,6 +77,7 @@ Shared helpers provide:
 - a minimal valid CAT062 record with mandatory items populated
 - byte-buffer to byte-array extraction helpers
 - record and data-block encoding helpers
+- FSPEC helpers for standalone record fixtures
 - truncation helpers for malformed-input tests
 - common range-failure assertions
 
@@ -58,62 +86,62 @@ Typed-code coverage policy:
 - closed code tables should have direct `fromCode(...)` coverage
 - sealed `Known` / `Unknown(code)` families should prove unknown decode and
   lossless re-encode
-- sparse code tables promoted from enums to sealed families should keep known
-  constant aliases stable while adding explicit unknown-wire coverage
-- golden vectors should stay byte-identical after model typing changes
+- golden vectors should remain byte-identical after model typing changes
 
 ## Coverage Matrix
 
 | FRN | Item | Primary suite | Current coverage |
 | --- | --- | --- | --- |
-| 1 | `I062/010` Data Source Identifier | `Cat062CodecGoldenVectorTest`, `Cat062CodecDataBlockTest`, `Cat062CodecSupportTest` | Literal record/block vectors for mandatory and dense records, plus public round-trip coverage |
+| 1 | `I062/010` Data Source Identifier | `Cat062CodecGoldenVectorTest`, `Cat062CodecDataBlockTest`, `Cat062CodecSupportTest` | Literal record and block vectors for mandatory and dense records, plus public round-trip coverage |
 | 3 | `I062/015` Service Identification | `Cat062CodecGoldenVectorTest`, `Cat062CodecDataBlockTest`, `Cat062CodecSupportTest` | FSPEC coverage, literal dense-record bytes, and end-to-end round-trips |
-| 4 | `I062/070` Time Of Track Information | `Cat062CodecGoldenVectorTest`, `Cat062CodecSupportTest`, `Cat062CodecDataBlockTest` | Literal minimal and dense record/block vectors, mandatory-item coverage, round-trip, and 24-bit overflow rejection |
+| 4 | `I062/070` Time Of Track Information | `Cat062CodecGoldenVectorTest`, `Cat062CodecSupportTest`, `Cat062CodecDataBlockTest` | Literal minimal and dense record and block vectors, mandatory-item coverage, round-trip, and 24-bit overflow rejection |
 | 5 | `I062/105` Calculated Track Position (WGS-84) | `Cat062CodecGoldenVectorTest`, `Cat062CodecDataBlockTest`, `Cat062CodecWireFixedItemsTest` | Dense-record literal bytes, record round-trip, and exact quantized WGS-84 wire round-trip |
-| 6 | `I062/100` Calculated Track Position (Cartesian) | `Cat062CodecDataBlockTest`, `Cat062CodecWireFixedItemsTest` | Record round-trip, signed 24-bit boundary coverage, overflow rejection |
+| 6 | `I062/100` Calculated Track Position (Cartesian) | `Cat062CodecDataBlockTest`, `Cat062CodecWireFixedItemsTest` | Record round-trip, signed 24-bit boundary coverage, and overflow rejection |
 | 7 | `I062/185` Calculated Track Velocity (Cartesian) | `Cat062CodecWireFixedItemsTest` | Direct wire round-trip coverage |
 | 8 | `I062/210` Calculated Acceleration (Cartesian) | `Cat062CodecWireFixedItemsTest` | Direct wire round-trip coverage |
 | 9 | `I062/060` Track Mode 3/A Code | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecSupportTest` | Dense-record literal bytes, spec-layout assertion, and public record round-trip |
-| 10 | `I062/245` Target Identification | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecDataBlockTest` | Dense-record literal bytes, all source enums, normalization, unsupported-character rejection, overlength rejection, public round-trip |
-| 11 | `I062/380` Aircraft Derived Data | `Cat062CodecAircraftDerivedDataTest` | Spec-layout assertions, per-subfield round-trips across all implemented subfields, dense round-trip, repetition coverage, selected bounds and truncation coverage, structured trajectory intent point encoding/decoding, typed-code mapping checks, and unknown-value round-trip coverage for forward-compatible trajectory-intent, Mode-S, and emitter-category codes |
-| 12 | `I062/040` Track Number | `Cat062CodecGoldenVectorTest`, `Cat062CodecSupportTest`, `Cat062CodecDataBlockTest` | Literal minimal and dense record/block vectors, mandatory item coverage, and public round-trips |
-| 13 | `I062/080` Track Status | `Cat062CodecGoldenVectorTest`, `Cat062CodecTrackStateTest`, `Cat062CodecDataBlockTest` | Literal minimal and dense record/block vectors, minimal and full extents, explicit absent/default/non-default extent semantics, extent-completeness validation, spec byte layout, typed-code mapping coverage, and public round-trip |
+| 10 | `I062/245` Target Identification | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecDataBlockTest` | Dense-record literal bytes, all source enums, normalization, unsupported-character rejection, overlength rejection, and public round-trip |
+| 11 | `I062/380` Aircraft Derived Data | `Cat062CodecAircraftDerivedDataTest` | Spec-layout assertions, per-subfield round-trips across all implemented subfields, dense round-trip, repetition coverage, selected bounds and truncation coverage, structured trajectory-intent point encoding and decoding, typed-code mapping checks, and unknown-value round-trip coverage for forward-compatible trajectory-intent, Mode-S, and emitter-category codes |
+| 12 | `I062/040` Track Number | `Cat062CodecGoldenVectorTest`, `Cat062CodecSupportTest`, `Cat062CodecDataBlockTest` | Literal minimal and dense record and block vectors, mandatory-item coverage, and public round-trips |
+| 13 | `I062/080` Track Status | `Cat062CodecGoldenVectorTest`, `Cat062CodecTrackStateTest`, `Cat062CodecDataBlockTest` | Literal minimal and dense record and block vectors, minimal and full extents, explicit absent/default/non-default extent semantics, extent-completeness validation, spec byte layout, typed-code mapping coverage, and public round-trip |
 | 14 | `I062/290` System Track Update Ages | `Cat062CodecTrackStateTest` | Sparse coverage, empty and dense population coverage |
-| 15 | `I062/200` Mode Of Movement | `Cat062CodecTrackStateTest` | Spec byte layout and enum/ADF decode coverage |
-| 16 | `I062/295` Track Data Ages | `Cat062CodecTrackStateTest` | Sparse multi-octet indicator coverage, out-of-range age rejection, truncation coverage |
+| 15 | `I062/200` Mode Of Movement | `Cat062CodecTrackStateTest` | Spec byte layout and enum or flag decode coverage |
+| 16 | `I062/295` Track Data Ages | `Cat062CodecTrackStateTest` | Sparse multi-octet indicator coverage, out-of-range age rejection, and truncation coverage |
 | 17 | `I062/136` Measured Flight Level | `Cat062CodecWireFixedItemsTest`, `Cat062CodecDataBlockTest` | Spec byte layout and record round-trip coverage |
 | 18 | `I062/130` Calculated Track Geometric Altitude | `Cat062CodecSupportTest`, `Cat062CodecEstimatedAccuraciesTest` | Dedicated public record round-trip and write-side overflow rejection, plus indirect quantization coverage via estimated-accuracy tests |
-| 19 | `I062/135` Calculated Track Barometric Altitude | `Cat062CodecWireFixedItemsTest`, `Cat062CodecDataBlockTest` | Record round-trip, flag decoding, overflow rejection |
+| 19 | `I062/135` Calculated Track Barometric Altitude | `Cat062CodecWireFixedItemsTest`, `Cat062CodecDataBlockTest` | Record round-trip, flag decoding, and overflow rejection |
 | 20 | `I062/220` Calculated Rate Of Climb/Descent | `Cat062CodecSupportTest`, `Cat062CodecEstimatedAccuraciesTest` | Dedicated public record round-trip and write-side overflow rejection, plus quantization coverage via estimated-accuracy tests |
-| 21 | `I062/390` Flight Plan Related Data | `Cat062CodecGoldenVectorTest`, `Cat062CodecFlightPlanTest` | Dense-record literal bytes, spec-layout assertion, per-subfield round-trips, full round-trip, repetition coverage, structured time of departure/arrival entry coverage, typed-code mapping coverage, ASCII behavior, and truncation coverage |
-| 22 | `I062/270` Target Size & Orientation | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecSupportTest` | Dense-record literal bytes, round-trip coverage for length-only, orientation-only, and width-extension encodings; explicit rejection of width without orientation; wrapped-orientation rejection; width overflow; public record round-trip |
-| 23 | `I062/300` Vehicle Fleet Identification | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecDataBlockTest` | Dense-record literal bytes, known and unknown code decode, record round-trip |
-| 24 | `I062/110` Mode 5 Data Reports & Extended Mode 1 Code | `Cat062CodecMode5Test` | Spec-layout assertion, each subfield independently, full round-trip, field-range failures, truncation coverage |
+| 21 | `I062/390` Flight Plan Related Data | `Cat062CodecGoldenVectorTest`, `Cat062CodecFlightPlanTest` | Dense-record literal bytes, spec-layout assertion, per-subfield round-trips, full round-trip, repetition coverage, structured time-of-departure or arrival entry coverage, typed-code mapping coverage, ASCII behavior, and truncation coverage |
+| 22 | `I062/270` Target Size & Orientation | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecSupportTest` | Dense-record literal bytes, round-trip coverage for length-only, orientation-only, and width-extension encodings, explicit rejection of width without orientation, wrapped-orientation rejection, width overflow, and public record round-trip |
+| 23 | `I062/300` Vehicle Fleet Identification | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecDataBlockTest` | Dense-record literal bytes, known and unknown code decode, and record round-trip |
+| 24 | `I062/110` Mode 5 Data Reports & Extended Mode 1 Code | `Cat062CodecMode5Test` | Spec-layout assertion, each subfield independently, full round-trip, field-range failures, and truncation coverage |
 | 25 | `I062/120` Track Mode 2 Code | `Cat062CodecWireFixedItemsTest` | Spec-layout assertion and direct round-trip coverage |
 | 26 | `I062/510` Composed Track Number | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecSupportTest` | Dense-record literal bytes, direct round-trip, and public record round-trip |
-| 27 | `I062/500` Estimated Accuracies | `Cat062CodecEstimatedAccuraciesTest` | Spec-layout assertion, each subfield independently, combined round-trip, overflow rejection, truncation coverage |
+| 27 | `I062/500` Estimated Accuracies | `Cat062CodecEstimatedAccuraciesTest` | Spec-layout assertion, each subfield independently, combined round-trip, overflow rejection, and truncation coverage |
 | 28 | `I062/340` Measured Information | `Cat062CodecMeasuredInformationTest` | Spec-layout assertion, each subfield independently, combined round-trip, report-type mapping coverage, bounds, and truncation coverage |
-| 34 | `RE` Reserved Expansion Field | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecSupportTest`, `Cat062CodecDataBlockTest` | Dense-record literal bytes, empty and maximum payloads, invalid length byte, truncation, record round-trip |
+| 34 | `RE` Reserved Expansion Field | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecSupportTest`, `Cat062CodecDataBlockTest` | Dense-record literal bytes, empty and maximum payloads, invalid length byte, truncation, and record round-trip |
 | 35 | `SP` Special Purpose Field | `Cat062CodecGoldenVectorTest`, `Cat062CodecWireFixedItemsTest`, `Cat062CodecSupportTest`, `Cat062CodecDataBlockTest` | Dense-record literal bytes, length-prefixed behavior, and public record round-trip |
 
 Unsupported FRN coverage:
 
 - `Cat062CodecSupportTest` verifies failure on unsupported FRN `2`
-- `Cat062CodecSupportTest` verifies failure on unsupported FRNs `29`, `30`, `31`, `32`, and `33`
+- `Cat062CodecSupportTest` verifies failure on unsupported FRNs `29`, `30`,
+  `31`, `32`, and `33`
 
 ## Explicit Partial Support
 
-These item areas are intentionally preserved as opaque payloads for now rather
-than exposed as fully decoded spec-level models:
+These areas are intentionally preserved as opaque payloads rather than exposed
+as fully decoded spec-level models:
 
-- `RE` and `SP` are modeled as raw pass-through payloads
+- `RE`
+- `SP`
 
-This keeps byte-level round-tripping stable while making the current support
-boundary explicit in the API and docs.
+This preserves wire compatibility without pretending that those payloads have
+first-class domain modeling today.
 
-## Malformed Input Coverage
+## Malformed-Input Coverage
 
-The current suite covers these failure categories directly:
+The current suite covers these failure classes directly:
 
 - wrong ASTERIX category
 - ASTERIX block length smaller than `3`
@@ -127,26 +155,15 @@ The current suite covers these failure categories directly:
 - overflow and range failures for write-validated fields
 - direct read-side truncation for every implemented fixed-width FRN
 
-The suite also verifies that typed semantic code fields preserve wire
-compatibility: known values decode to named variants, and the modeled unknown
-branches re-encode their original wire values unchanged.
+Public API behavior also pinned by tests:
 
-Assertion policy:
-
-- exact messages are asserted for explicit `require(...)` failures
-- representative truncation paths are asserted as contextual
-  `IllegalArgumentException` failures that include CAT062 item references
-  and, for compound items, subfield context where available
-
-Public API note:
-
-- `Cat062Codec` is covered through both `ByteBuffer` and `ByteArray`
-  convenience entry points for record and data-block round trips
+- `Cat062Codec` is covered through both `ByteBuffer` and `ByteArray` entry
+  points
 - representative validation and decode failures are asserted through the
-  `ByteArray` overloads so they stay behaviorally aligned with the
+  `ByteArray` overloads so those wrappers remain behaviorally aligned with the
   `ByteBuffer` core path
-- nested data-block decode failures include the one-based record ordinal in
-  the asserted public message
+- nested data-block failures include the one-based record ordinal
+- item-specific failures include CAT062 item references where available
 
 ## Verification
 
@@ -155,7 +172,7 @@ Run:
 - `mvn -Dmaven.repo.local=/tmp/m2 clean test`
 - `mvn -Dmaven.repo.local=/tmp/m2 verify`
 
-Review:
+Review when needed:
 
 - `target/site/jacoco/jacoco.csv`
 - `target/surefire-reports`
@@ -163,17 +180,17 @@ Review:
 The suite should be considered healthy when:
 
 - all tests pass
-- each implemented non-spare UAP item is exercised directly or through a
-  stable public round-trip
-- top-level record and data-block encoding is pinned by literal golden vectors
+- each implemented non-spare UAP item is exercised directly or through a stable
+  public round-trip
+- representative records and data blocks remain pinned by exact golden vectors
 - compound items have both positive and malformed-input coverage
 
-## Remaining Follow-Up Gaps
+## Remaining Follow-Up
 
-The suite now covers the planned public-record, compound-item, and fixed-width
-read-side gaps from this iteration, including literal record/data-block vectors
-for representative CAT062 payloads.
+The current suite covers the planned public-record, compound-item, and
+fixed-width read-side gaps for the present codec surface.
 
 The main remaining follow-up item is:
 
-- optional JaCoCo target-setting once the current suite shape stabilizes
+- optional JaCoCo target-setting once the suite shape is stable enough to make
+  a coverage threshold meaningful


### PR DESCRIPTION
## Summary
- refresh the top-level docs around the current CAT062 codec surface and support boundary
- expand the architecture and testing docs so they match the implementation and regression strategy
- add a practical article explaining how CAT062 works, including FSPEC, FRNs, UAP order, and a worked example

Closes #7